### PR TITLE
[Feature] Allow multiple warnings for workspaces with multiple package.json

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,7 +1,7 @@
 trigger:
-  tags:
+  branches:
     include:
-    - v*
+      - refs/tags/v*
 
 strategy:
   matrix:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"clean": "rimraf node_modules",
 		"compile": "webpack --mode development",
 		"deploy": "vsce publish --yarn",
+		"dev": "webpack --mode development --watch",
 		"install-command": "yarn",
 		"lint": "eslint src --ext ts",
 		"prepublish:1": "npm-run-all --serial clean install-command",
@@ -58,8 +59,7 @@
 		"test:int": "node ./out/test/runTest.js",
 		"test:unit": "mocha -r ts-node/register --recursive '**/__tests__/*.test.ts'",
 		"test-compile": "tsc -p ./",
-		"vscode:prepublish": "npm-run-all --serial prepublish:*",
-		"webpack-dev": "webpack --mode development --watch"
+		"vscode:prepublish": "npm-run-all --serial prepublish:*"
 	},
 	"devDependencies": {
 		"@types/deep-equal": "^1.0.1",

--- a/src/PackageChangeWatcher.ts
+++ b/src/PackageChangeWatcher.ts
@@ -148,9 +148,17 @@ export class PackageChangeWatcher {
 	}
 
 	private warn() {
+		let lockPath = this.basePath;
+		
+		if (vscode.workspace.rootPath) {
+			const remainingPath = this.basePath.replace(vscode.workspace.rootPath, '');
+
+			lockPath = remainingPath || 'root';
+		} 
+
 		if (!this.doubleSafeGuard) {
 			vscode.window.showWarningMessage(
-				`One of the project dependencies has been updated, please run ${
+				`One of the project dependencies at "${lockPath}" has been updated, please run ${
 				this.isYarn ? 'yarn' : 'npm ci'
 				}!`
 			);


### PR DESCRIPTION
# PR Description
- Updated to add folder path to warning

## Motivation and Context
Prior to this change when more than 1 lock file changed in a workspace, the user would get only 1 warning. Now they'll get a warning for each changed package.

## How Has This Been Tested
Manually, debugging on linux.

## Types of changes
<!-- - Refactoring / dependency upgrade / docs change -->
<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to change) -->

## Visual screenshots
![2020-07-05_14-48](https://user-images.githubusercontent.com/6427905/86534237-c708bb00-bece-11ea-8d6c-a66198b17a2a.png)


PR comments: Please use the [emoji guide](https://github.com/erikthedeveloper/code-review-emoji-guide) to categorise your comments
